### PR TITLE
Fix image link

### DIFF
--- a/goog/nocss/index.html
+++ b/goog/nocss/index.html
@@ -1,15 +1,15 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <link rel="icon" href="/goog/img/goog.webp">
+  <link rel="icon" href="/img/goog.webp">
   <title>Goog...</title>
   <meta name="robots" content="index, follow">
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
   <meta property="og:title" content="Goog...">
   <meta property="og:description" content="Goog...">
-  <meta property="og:image" content="/goog/img/goog.webp">
+  <meta property="og:image" content="/img/goog.webp">
 </head>
 <body>
-  <img src="/goog/img/goog.webp" width="50%" alt='a picture of a cat named shark with the caption "Goog...".'>
+  <img src="/img/goog.webp" width="50%" alt='a picture of a cat named shark with the caption "Goog...".'>
 </body>
 </html>


### PR DESCRIPTION
also, it appears as though the 404 page subtitles do not work on any subdomain other than `s.soggy.cat` due to cross origin shit, and the video doesn't play at all on chromium, although works fine on firefox. (getImageData is insecure)